### PR TITLE
Handle hard-links inside of .HFS+ Private Directory Data

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Alexandre Bique <bique.alexandre@gmail.com>
+Tor Arne Vestbø <torarnv@gmail.com>

--- a/src/readdir.cc
+++ b/src/readdir.cc
@@ -27,8 +27,8 @@ int tmfs_readdir(const char * path, void * buf, fuse_fill_dir_t filler_cb, off_t
   while ((entry = readdir(dir)))
   {
     // stat the file pointed by entry
-    bfs::path path = bfs::path(real_path) / entry->d_name;
-    if (stat(path.c_str(), &stbuf))
+    bfs::path file_path = bfs::path(path) / entry->d_name;
+    if (tmfs_getattr(file_path.c_str(), &stbuf))
       continue;
     stbuf.st_mode |= 0755;
     // report the entry


### PR DESCRIPTION
By using regular stat on the file entries in each hard-linked
directory we would report back the same "broken" directories as
you would normally see without tmfs (empty size and weird permissions
and link count).

This caused tools such as find to only recurse to the next level
of hard-linked directories, and then stop. Navigating the directory
structure manually worked fine though, as each step would cause a
new call to readdir(), which would handle that first level of
directory hard-links.

We circumvent this problem by not stat'ing the files inside the
private data directly, but mapping the file entries to the original
path, and then going through our own stat implementation which deals
with the hard-linked directories.
