### PR TITLE
Fixes handling of symlinks that point to ".HFS+ Private" directories

### DIFF
--- a/src/get_real_path.cc
+++ b/src/get_real_path.cc
@@ -20,7 +20,7 @@ static std::string _get_real_path(const std::string & str)
   {
     real_path /= *it;
     // Does the file exists ?
-    if (stat(real_path.string().c_str(), &stbuf))
+    if (lstat(real_path.string().c_str(), &stbuf))
       return real_path.string();
 
     // Is the file a dir_id ?


### PR DESCRIPTION
Previously, if a symlink points to a directory residing in the ".HFS+
Private" folder, `get_real_path` would incorrectly resolve the symlink.
This commit changes `get_real_path` to use `lstat` instead of `stat`, so
that it will correctly preserve the symlink.

Fixes #16