### PR TITLE
Allow the HFS mount directory to be a relative path

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -10,7 +10,7 @@ int main(int argc, char ** argv)
   }
 
   /* global structure setup */
-  tmfs::instance().hfs_root_ = argv[1];
+  tmfs::instance().hfs_root_ = fs::absolute(fs::path(argv[1]));
   --argc;
   for (int i = 1; i < argc; ++i)
     argv[i] = argv[i + 1];

--- a/src/tmfs.hh
+++ b/src/tmfs.hh
@@ -27,10 +27,10 @@ namespace fs = std::filesystem;
 
 /** this is the global structure of tmfs */
 struct tmfs {
-  inline const std::string & hfs_root() const noexcept { return hfs_root_; }
+  inline const fs::path & hfs_root() const noexcept { return hfs_root_; }
   static inline tmfs & instance() { static tmfs i; return i; }
 
-  std::string  hfs_root_; // the hfs root
+  fs::path  hfs_root_; // the hfs root
 };
 
 /** transforms a virtual paths in the tmfs's root to the real path in hfs's root */


### PR DESCRIPTION
When creating the root path, convert it to an absolute path before
daemonizing.  Previously, relative paths worked only when running in
foreground mode, but when daemonizing the process would move it's cwd to
root so it would no longer work.